### PR TITLE
Replace nvm and rbenv with mise

### DIFF
--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -29,14 +29,10 @@ and . (code --locate-shell-integration-path fish)
 
 fish_config prompt choose arrow
 
-function __check_nvm --on-variable PWD --description 'attempt to install node version from .nvmrc'
-  status --is-command-substitution; and return
-  nvm install 2>/dev/null
-end
-__check_nvm
-
-if type -q rbenv
-  status --is-interactive; and rbenv init - fish | source
+# mise: polyglot runtime version manager (node, ruby, etc.)
+# https://mise.jdx.dev/
+if type -q mise
+  mise activate fish | source
 end
 
 # Speed precommit up since I'm really working in rails

--- a/.config/fish/fish_plugins
+++ b/.config/fish/fish_plugins
@@ -2,4 +2,3 @@ jorgebucaran/fisher
 jhillyerd/plugin-git
 jethrokuan/z
 jethrokuan/fzf
-jorgebucaran/nvm.fish

--- a/.config/fish/setup.fish
+++ b/.config/fish/setup.fish
@@ -16,13 +16,10 @@ if not functions -q fisher
   fisher update
 end
 
-if not nvm list lts > /dev/null
+if type -q mise
   echo
-  echo "📜 NVM setup"
-
-  nvm install lts
-  set --universal nvm_default_version lts
-
-  nvm list
+  echo "🔧 Installing default runtimes via mise"
   echo
+
+  mise install
 end

--- a/.config/fish/setup.fish
+++ b/.config/fish/setup.fish
@@ -15,11 +15,3 @@ if not functions -q fisher
 
   fisher update
 end
-
-if type -q mise
-  echo
-  echo "🔧 Installing default runtimes via mise"
-  echo
-
-  mise install
-end

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -1,0 +1,3 @@
+[tools]
+node = "lts"
+ruby = "latest"

--- a/Brewfile
+++ b/Brewfile
@@ -17,12 +17,10 @@ brew "bat"
 brew "bison"
 # User-friendly command-line shell for UNIX-like operating systems
 brew "fish"
-# Thin wrapper around chruby to make it work with the Fish shell
-brew "chruby-fish"
 # Load/unload environment variables based on $PWD
 brew "direnv"
-# Fast and simple Node.js version manager
-brew "fnm"
+# Polyglot runtime version manager (Node, Ruby, Python, Go, etc.)
+brew "mise"
 # GNU database manager
 brew "gdbm"
 # GitHub command-line tool
@@ -49,10 +47,6 @@ brew "mysql"
 brew "openssl@3"
 # Pinentry for GPG on Mac
 brew "pinentry-mac"
-# Ruby version manager
-brew "rbenv"
-# Install Ruby, JRuby, Rubinius, TruffleRuby, or mruby
-brew "ruby-install"
 # Version control system designed to be a better CVS
 brew "subversion"
 # Python package manager and tool runner (provides uvx, required for fabric-rti-mcp)

--- a/Brewfile.codespaces
+++ b/Brewfile.codespaces
@@ -5,17 +5,13 @@ brew "ack"
 brew "bat"
 # User-friendly command-line shell for UNIX-like operating systems
 brew "fish"
-# Thin wrapper around chruby to make it work with the Fish shell
-brew "chruby-fish"
 # Load/unload environment variables based on $PWD
 brew "direnv"
-# Fast and simple Node.js version manager
-brew "fnm"
 # HTTP load generator, ApacheBench (ab) replacement
 brew "hey"
 # Lightweight and flexible command-line JSON processor
 brew "jq"
-# Ruby version manager
-brew "rbenv"
+# Polyglot runtime version manager (Node, Ruby, Python, Go, etc.)
+brew "mise"
 # CLI tool to pay respects
 brew "timescam/tap/pay-respects"


### PR DESCRIPTION
`mise` is a rust-based fast version manager that manages node, ruby, python, and go in one tool

https://github.com/jdx/mise