### PR TITLE
Add Copilot CLI skills: bear + weekly-reflection

### DIFF
--- a/.copilot/skills/bear/SKILL.md
+++ b/.copilot/skills/bear/SKILL.md
@@ -24,7 +24,7 @@ configuration and Bear's own FAQ recommends it for CLI/terminal use.
 ```bash
 BC=/Applications/Bear.app/Contents/MacOS/bearcli
 "$BC" --help          # top-level help + subcommand list
-"$BC" <sub> --help    # detailed help for any subcommand
+"$BC" "<subcommand>" --help    # detailed help for any subcommand
 ```
 
 Requires **Bear 2.8+**. If the binary isn't there, check for a non-default app

--- a/.copilot/skills/bear/SKILL.md
+++ b/.copilot/skills/bear/SKILL.md
@@ -70,10 +70,10 @@ Mutations:
 - **Pipe body content via stdin to avoid escaping bugs.** `create`/`append`/
   `edit`/`overwrite` accept `--content`/text args that interpret `\n \t \r \\`,
   but **stdin is NOT unescaped** — so piping literal Markdown is safest:
-  `printf '%s' "$body" | "$BC" append <id> --position beginning`.
+  `printf '%s' "$body" | "$BC" append "<note-id>" --position beginning`.
 - **Back up before destructive writes.** Before `overwrite` (or a large `edit`),
   dump the current note so a bad write is recoverable:
-  `"$BC" cat <id> > "/tmp/bear-backup-$(date +%Y%m%d-%H%M%S).md"`.
+  `"$BC" cat "<note-id>" > "/tmp/bear-backup-$(date +%Y%m%d-%H%M%S).md"`.
 - **Attachments are protected.** Edits that would drop attachments are rejected
   unless re-run with `--force`; read the rejection before forcing.
 - **Preserve tags.** Bear derives tags from `#hashtags` in the body and title from

--- a/.copilot/skills/bear/SKILL.md
+++ b/.copilot/skills/bear/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: bear
+description: >-
+  Read from and write to the user's Bear notes (Bear.app on macOS) via the
+  bundled `bearcli` binary. Use whenever the user wants to search, read, list,
+  create, append/prepend, edit, tag, pin, archive, or otherwise work with their
+  Bear notes from an agent — e.g. "search my Bear notes", "what's in my Bear note
+  about X", "add this to Bear", "create a Bear note", "append to my … note in
+  Bear", "tag/pin/archive a Bear note". Bear is a local macOS notes app; there is
+  no web API — all access goes through the local `bearcli`.
+---
+
+# Bear notes via `bearcli`
+
+Bear ships a command-line interface, `bearcli`, that is the way to read and write
+Bear notes from a terminal agent. Prefer it over any Bear MCP server — it needs no
+configuration and Bear's own FAQ recommends it for CLI/terminal use.
+
+## The binary
+
+`bearcli` is bundled inside the app and is **not on `PATH`**. Call it by full path
+(macOS default install):
+
+```bash
+BC=/Applications/Bear.app/Contents/MacOS/bearcli
+"$BC" --help          # top-level help + subcommand list
+"$BC" <sub> --help    # detailed help for any subcommand
+```
+
+Requires **Bear 2.8+**. If the binary isn't there, check for a non-default app
+location (`mdfind -name bearcli` or `mdfind "kMDItemKind == 'Application'" | grep -i bear`)
+and tell the user if Bear isn't installed / is too old rather than guessing.
+
+**Self-documenting:** the CLI is fully described by its own help. When unsure of a
+flag, run `"$BC" <sub> --help` (or `"$BC" help all`) instead of assuming.
+
+## Subcommands (surface)
+
+Reads:
+- `search [query]` — Bear search syntax (`#tag`, `!#tag` exact, `#*/sub`,
+  `@today`, `@lastNdays`, `@date(YYYY-MM-DD)`, `@title`, `@tagged`, `"exact"`,
+  `-negation`, …). `--sort`, `--limit`, `--offset`, `--location notes|trash|archive|all`,
+  `--count`.
+- `list` — list notes without a query (e.g. `--tag`).
+- `show` — structured note fields (id, title, tags, hash, length, dates, …).
+  Content is excluded unless you pass `--fields all,content`.
+- `cat` — raw note content (Markdown). `--offset`/`--limit` for byte slicing.
+- `search-in` — find exact string occurrences within a single note.
+
+Mutations:
+- `create` — new note (returns the new note id — capture it).
+- `append` — add content; `--position beginning|end`. **`beginning` = prepend**
+  (inserts after the title and any top-placed tags); `end` is the default.
+- `edit` — find exact text and `--replace` / `--insert-after` / `--insert-before`;
+  `--all`, `--ignore-case`, `--word`. Repeat `--find` for batch edits.
+- `overwrite` — replace a note's entire content (optional `--base <hash>` for
+  optimistic-concurrency; without it the CLI write is unconditional).
+- `tags`, `pin`, `trash`, `archive`, `restore`, `attachments`, `open`.
+- `mcp-server` — stdio MCP transport (only if you specifically need MCP; not needed
+  for CLI use).
+
+## Working rules (important)
+
+- **Identify notes by `id`, not title, for writes.** Titles collide and change.
+  `search`/`show` with `--format json --fields id,title` to resolve the id first,
+  and **confirm the target with the user** before any mutation.
+- **Mutations are silent on success — the exit code is the only signal.** Do not
+  treat "no output" as failure; do treat a nonzero exit as failure. `--format json`
+  applies to *reads* only.
+- **Pipe body content via stdin to avoid escaping bugs.** `create`/`append`/
+  `edit`/`overwrite` accept `--content`/text args that interpret `\n \t \r \\`,
+  but **stdin is NOT unescaped** — so piping literal Markdown is safest:
+  `printf '%s' "$body" | "$BC" append <id> --position beginning`.
+- **Back up before destructive writes.** Before `overwrite` (or a large `edit`),
+  dump the current note so a bad write is recoverable:
+  `"$BC" cat <id> > "/tmp/bear-backup-$(date +%Y%m%d-%H%M%S).md"`.
+- **Attachments are protected.** Edits that would drop attachments are rejected
+  unless re-run with `--force`; read the rejection before forcing.
+- **Preserve tags.** Bear derives tags from `#hashtags` in the body and title from
+  the first heading — when using `overwrite`, keep the existing tag line / title
+  intact unless the user asked to change them.
+- **Read-only by default.** Prefer `search`/`cat`/`show` to answer questions; only
+  create/edit/overwrite when the user asks to change a note, and show a draft first.
+
+## Related skill
+
+For the specific weekly-work-journal workflow (priming this week's diary entry from
+the status updates), use the **weekly-reflection** skill, which builds on this
+one.

--- a/.copilot/skills/weekly-reflection/SKILL.md
+++ b/.copilot/skills/weekly-reflection/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: weekly-reflection
+description: >-
+  Prime this week's entry in the Bear "Weekly Work Diary" note from the weekly
+  status updates. Use when the user says "prime my weekly journal", "update my
+  work diary", "add this week's status to my Bear journal", "start this week's
+  diary entry", or after posting the weekly GitHub status updates and wanting
+  them copied into the Bear work journal. Fills a fixed template (Goal Progress,
+  Work done, optional Wins/Fails/Kudos/Decisions/Ideas), formats each status
+  update under a linked h3, and prepends the finished block to the top of the
+  ongoing diary note.
+---
+
+# Prime the weekly Bear work-journal entry
+
+Build this week's entry from the fixed template + the weekly status update(s) and
+**prepend** it to the top of the ongoing Bear "Weekly Work Diary" note (newest
+week first).
+
+## Why this journal exists
+
+Two purposes — keep the entry useful for both:
+
+1. **Continuous self-improvement.** An honest weekly reflection on how the week
+   went (hence the Wins / Fails / Goal Progress sections).
+2. **Evidence for company self-reflections.** It's the body of evidence drawn on
+   for the formal half-year self-reflection (kept in the `theinterned/reflections`
+   repo). Concrete, linkable, attributable entries matter.
+
+Per the note's own convention, mark work the user is **directly responsible for**
+with a `⭐`.
+
+## Tooling
+
+- **Bear:** driven through the bundled `bearcli` binary
+  (`/Applications/Bear.app/Contents/MacOS/bearcli`, Bear 2.8+, not on `PATH`). See
+  the **`bear`** skill for the full command surface and working rules (identify by
+  id, mutations are silent-on-success, pipe body via stdin, back up before
+  overwrite). This skill assumes those rules.
+- **GitHub:** `gh` for fetching the status-update comment bodies and issue titles.
+
+## Locate the diary note (do NOT hardcode the id)
+
+The note rotates each half-year (e.g. `FY27 H1` → `FY27 H2`), so find the current
+one and **confirm with the user before writing**:
+
+```bash
+BC=/Applications/Bear.app/Contents/MacOS/bearcli
+"$BC" search "Weekly Work Diary" --sort created:desc --format json --fields id,title,modified
+```
+
+Pick the newest note whose title **starts with** `Weekly Work Diary` (ignore the
+`... Self Reflection ...` notes). Capture its `id`.
+
+### Note structure (match it exactly)
+
+```
+# Weekly Work Diary FY27 H1 • <date range>      <- title (h1)
+#work/github #work/github/reflektive #.diary/work#   <- tag line
+<blank>
+⭐ *Note for epic and batch updates ...*         <- standing note line
+<blank>
+# 2026-07-10                                     <- most recent week (h1)
+...week block...
+---                                              <- each week block ends with ---
+# 2026-07-03
+...
+---
+```
+
+The stable header (title + tag line + `⭐` note line) stays at the top. Week blocks
+follow, **newest first**, each ending with `---`. The new entry is inserted
+**immediately before the first `# YYYY-MM-DD` heading**.
+
+## Build the entry
+
+Start from `references/template.md`. Replace `{{DATE}}` with **today's date**
+(`YYYY-MM-DD`, from the environment's current datetime).
+
+### First-responder (FR) weeks
+
+If the user was on first-responder rotation, insert this line right after the
+`# <date>` heading and before `## 🥅 Goal Progress` (add any noteworthy FR notes
+under it):
+
+```
+## 🚨 I’m FR this week so expect lighter progress …
+```
+
+Otherwise omit it.
+
+### 🥅 Goal Progress (always filled)
+
+Fill a sub-bullet under **each** goal. First read the status update(s) and draft a
+candidate line for any goal the week's work speaks to, then **prompt the user goal
+by goal** — show your suggested line, let them confirm/edit, and flag which goals
+have a strong candidate. Typical mappings for this initiative:
+
+- **Goal 1 (TT violations → zero):** the sanitization / DOMPurify / preset / spike work.
+- **Goal 3 (communicate more broadly):** decision-log entries, ADRs, Core UX discussions.
+
+If a goal genuinely had no movement, `No progress` is a fine answer — don't invent one.
+
+### 🏗️ Work done (all updates written this week)
+
+Include **every** status update the user wrote this week (e.g. the epic-level
+update *and* the executive rollup), each as its own block.
+
+**First, locate this week's updates** (resolution order — this skill is pinned to
+this Mac by Bear, but the status updates may have been written on another machine,
+so degrade gracefully):
+
+1. **Handoff manifest** — if `~/.copilot/state/weekly-status/latest.json` exists
+   *and* its `week_start` is the current week, use its `updates[]` (each has
+   `repo`, `issue`, `title`, `comment_url`). This is written best-effort by the
+   `weekly-status-update` skill at the end of a run; **it may be absent** (first
+   run, or the update was posted on another machine) — that's expected, just fall
+   through.
+2. **Local artifacts** — otherwise, if you're in the same session/machine where the
+   updates were drafted, the sanitized `*.post.md` files in the status-update
+   session's `files/` dir are equivalent source.
+3. **Ask the user** — otherwise, ask them to paste the comment URL(s) for the
+   update(s) they posted this week. Never guess or invent them.
+
+Then, for each update:
+
+1. **Fetch the posted body and issue title** from the comment URL
+   (`https://github.com/<owner>/<repo>/issues/<n>#issuecomment-<id>`):
+
+   ```bash
+   gh api repos/<owner>/<repo>/issues/comments/<id> -q .body   # markdown body
+   gh issue view <n> --repo <owner>/<repo> --json title -q .title
+   ```
+
+   (If using a local `*.post.md` artifact from step 2, that body is equivalent.)
+2. **h3 title line**, mirroring the note's established style — the GitHub page
+   title, linked to the comment:
+
+   ```
+   ### [<issue title> · Issue #<n> · github/<repo>](<comment-url>)
+   ```
+3. **Clean the body:** strip every `<!-- data ... -->` Howie marker line (and the
+   blank lines they leave), then **demote every ATX heading by one level** so the
+   update's sections nest under the h3 title (`### Update` → `#### Update`, etc.).
+4. Order the blocks epic-level update(s) first, then the rollup (the user can
+   reorder on review).
+
+
+Also leave room for **work that happened outside the status updates** — ask the
+user if anything should be added manually, and mark ⭐ items they own.
+
+### 🏆 Wins / 💩 Fails / 🙏 Kudos / 🌳 Decisions / 🔮 Ideas (optional)
+
+Most weeks several of these are empty. **Ask the user about each one** (surface any
+obvious candidate you spotted in the week's work). **If a section has no content,
+delete its heading entirely** — don't leave an empty heading.
+
+## Review, back up, then prepend
+
+1. Write the assembled week block to a local draft file and **show it to the user
+   for confirmation.** Never write to Bear before they approve.
+2. **Back up first.** Dump the whole current note to a timestamped file so a bad
+   write is always recoverable:
+
+   ```bash
+   BC=/Applications/Bear.app/Contents/MacOS/bearcli
+   "$BC" cat <id> > "/tmp/diary-backup-$(date +%Y%m%d-%H%M%S).md"
+   ```
+3. **Prepend via read → splice → overwrite** (robust against dynamic anchors):
+
+   ```bash
+   # new-week.md = the approved entry (ends with a trailing `---`)
+   "$BC" cat <id> > /tmp/diary-current.md
+   python3 - "$id" /tmp/diary-current.md /tmp/new-week.md <<'PY'
+   import re, subprocess, sys
+   note_id, cur_path, new_path = sys.argv[1], sys.argv[2], sys.argv[3]
+   cur = open(cur_path, encoding="utf-8").read()
+   block = open(new_path, encoding="utf-8").read().rstrip("\n") + "\n"
+   m = re.search(r"(?m)^# \d{4}-\d{2}-\d{2}\b", cur)   # first existing week heading
+   if not m:
+       sys.exit("Could not find a week heading to insert before — aborting.")
+   out = cur[:m.start()] + block + cur[m.start():]
+   subprocess.run([BC := "/Applications/Bear.app/Contents/MacOS/bearcli",
+                   "overwrite", note_id], input=out, text=True, check=True)
+   PY
+   ```
+
+4. **Verify:** `bearcli cat <id> | head -40` and confirm the new `# <date>` block
+   now sits directly under the `⭐` header, above last week's block, with its
+   trailing `---` intact. If anything looks wrong, restore from the backup with
+   `overwrite`.
+
+## Golden rules
+
+- **Locate the note dynamically; never hardcode the note id** — it rotates each half.
+- **Draft → confirm → back up → overwrite.** Always show the entry and dump a
+  backup before touching the live note.
+- **Prepend, don't append** — newest week goes at the top, under the standing header.
+- **Fill Goal Progress every week**, prompting goal by goal; drop empty optional
+  sections entirely.
+- **Include every status update written**, each demoted one heading level under a
+  linked h3, with the Howie `<!-- data -->` markers stripped.

--- a/.copilot/skills/weekly-reflection/SKILL.md
+++ b/.copilot/skills/weekly-reflection/SKILL.md
@@ -149,16 +149,22 @@ Then, for each update:
 Also leave room for **work that happened outside the status updates** — ask the
 user if anything should be added manually, and mark ⭐ items they own.
 
-### 🏆 Wins / 💩 Fails / 🙏 Kudos / 🌳 Decisions / 🔮 Ideas (optional)
+### 🏆 Wins / 💩 Fails / 🙏 Kudos / 🌳 Decisions / 🔮 Ideas (optional content — but always ask)
 
-Most weeks several of these are empty. **Ask the user about each one** (surface any
-obvious candidate you spotted in the week's work). **If a section has no content,
-delete its heading entirely** — don't leave an empty heading.
+These are the heart of the reflection, not an afterthought. **You MUST walk the
+user through all five, one at a time** — even the ones you think are empty. For
+each: surface any candidate you spotted in the week's work, then let the user
+add, edit, or skip it. **Never silently omit a section** because you found no
+candidate — ask first. Only *after* the user has decided on each, **delete the
+headings for the ones left empty** (don't leave an empty heading).
 
 ## Review, back up, then prepend
 
-**1. Draft and confirm.** Write the assembled week block to a local draft file and
-**show it to the user for confirmation.** Never write to Bear before they approve.
+**1. Draft and confirm.** First make sure you've already **prompted goal by goal
+and walked the user through all five optional sections** — don't assemble the
+final block until both are done. Then write the assembled week block to a local
+draft file and **show it to the user for confirmation.** Never write to Bear
+before they approve.
 
 **2. Back up first.** Dump the whole current note to a timestamped file so a bad
 write is always recoverable (`NOTE_ID` = the diary note id you resolved above):
@@ -199,7 +205,9 @@ trailing `---` intact. If anything looks wrong, restore from the backup with
 - **Draft → confirm → back up → overwrite.** Always show the entry and dump a
   backup before touching the live note.
 - **Prepend, don't append** — newest week goes at the top, under the standing header.
-- **Fill Goal Progress every week**, prompting goal by goal; drop empty optional
-  sections entirely.
+- **Fill Goal Progress every week**, prompting goal by goal.
+- **Walk the user through all five optional sections (Wins / Fails / Kudos /
+  Decisions / Ideas) one at a time** — surface candidates, never silently drop
+  them; only delete a heading after the user confirms it's empty.
 - **Include every status update written**, each demoted one heading level under a
   linked h3, with the Howie `<!-- data -->` markers stripped.

--- a/.copilot/skills/weekly-reflection/SKILL.md
+++ b/.copilot/skills/weekly-reflection/SKILL.md
@@ -140,8 +140,8 @@ Then, for each update:
    ### [<issue title> · Issue #<n> · github/<repo>](<comment-url>)
    ```
 3. **Clean the body:** strip every `<!-- data ... -->` Howie marker line (and the
-   blank lines they leave), then **demote every ATX heading by one level** so the
-   update's sections nest under the h3 title (`### Update` → `#### Update`, etc.).
+   blank lines they leave), then **demote ATX headings so they are strictly below
+   the h3 title line** (minimum `####`, e.g. `##` → `####`, `###` → `####`, `####` → `#####`).
 4. Order the blocks epic-level update(s) first, then the rollup (the user can
    reorder on review).
 

--- a/.copilot/skills/weekly-reflection/SKILL.md
+++ b/.copilot/skills/weekly-reflection/SKILL.md
@@ -157,38 +157,41 @@ delete its heading entirely** — don't leave an empty heading.
 
 ## Review, back up, then prepend
 
-1. Write the assembled week block to a local draft file and **show it to the user
-   for confirmation.** Never write to Bear before they approve.
-2. **Back up first.** Dump the whole current note to a timestamped file so a bad
-   write is always recoverable:
+**1. Draft and confirm.** Write the assembled week block to a local draft file and
+**show it to the user for confirmation.** Never write to Bear before they approve.
 
-   ```bash
-   BC=/Applications/Bear.app/Contents/MacOS/bearcli
-   "$BC" cat <id> > "/tmp/diary-backup-$(date +%Y%m%d-%H%M%S).md"
-   ```
-3. **Prepend via read → splice → overwrite** (robust against dynamic anchors):
+**2. Back up first.** Dump the whole current note to a timestamped file so a bad
+write is always recoverable (`NOTE_ID` = the diary note id you resolved above):
 
-   ```bash
-   # new-week.md = the approved entry (ends with a trailing `---`)
-"$BC" cat <id> > /tmp/diary-current.md
-python3 - <id> /tmp/diary-current.md /tmp/new-week.md <<'PY'
+```bash
+BC=/Applications/Bear.app/Contents/MacOS/bearcli
+NOTE_ID="paste-the-resolved-note-id"
+"$BC" cat "$NOTE_ID" > "/tmp/diary-backup-$(date +%Y%m%d-%H%M%S).md"
+```
+
+**3. Prepend via read → splice → overwrite** (robust against dynamic anchors):
+
+```bash
+# new-week.md = the approved entry (ends with a trailing `---`)
+"$BC" cat "$NOTE_ID" > /tmp/diary-current.md
+python3 - "$NOTE_ID" /tmp/diary-current.md /tmp/new-week.md <<'PY'
 import re, subprocess, sys
-   note_id, cur_path, new_path = sys.argv[1], sys.argv[2], sys.argv[3]
-   cur = open(cur_path, encoding="utf-8").read()
-   block = open(new_path, encoding="utf-8").read().rstrip("\n") + "\n"
-   m = re.search(r"(?m)^# \d{4}-\d{2}-\d{2}\b", cur)   # first existing week heading
-   if not m:
-       sys.exit("Could not find a week heading to insert before — aborting.")
-   out = cur[:m.start()] + block + cur[m.start():]
-   subprocess.run([BC := "/Applications/Bear.app/Contents/MacOS/bearcli",
-                   "overwrite", note_id], input=out, text=True, check=True)
-   PY
-   ```
+note_id, cur_path, new_path = sys.argv[1], sys.argv[2], sys.argv[3]
+cur = open(cur_path, encoding="utf-8").read()
+block = open(new_path, encoding="utf-8").read().rstrip("\n") + "\n"
+m = re.search(r"(?m)^# \d{4}-\d{2}-\d{2}\b", cur)   # first existing week heading
+if not m:
+    sys.exit("Could not find a week heading to insert before — aborting.")
+out = cur[:m.start()] + block + cur[m.start():]
+subprocess.run(["/Applications/Bear.app/Contents/MacOS/bearcli",
+                "overwrite", note_id], input=out, text=True, check=True)
+PY
+```
 
-4. **Verify:** `bearcli cat <id> | head -40` and confirm the new `# <date>` block
-   now sits directly under the `⭐` header, above last week's block, with its
-   trailing `---` intact. If anything looks wrong, restore from the backup with
-   `overwrite`.
+**4. Verify:** `"$BC" cat "$NOTE_ID" | head -40` and confirm the new `# <date>` block
+now sits directly under the `⭐` header, above last week's block, with its
+trailing `---` intact. If anything looks wrong, restore from the backup with
+`overwrite`.
 
 ## Golden rules
 

--- a/.copilot/skills/weekly-reflection/SKILL.md
+++ b/.copilot/skills/weekly-reflection/SKILL.md
@@ -170,9 +170,9 @@ delete its heading entirely** — don't leave an empty heading.
 
    ```bash
    # new-week.md = the approved entry (ends with a trailing `---`)
-   "$BC" cat <id> > /tmp/diary-current.md
-   python3 - "$id" /tmp/diary-current.md /tmp/new-week.md <<'PY'
-   import re, subprocess, sys
+"$BC" cat <id> > /tmp/diary-current.md
+python3 - <id> /tmp/diary-current.md /tmp/new-week.md <<'PY'
+import re, subprocess, sys
    note_id, cur_path, new_path = sys.argv[1], sys.argv[2], sys.argv[3]
    cur = open(cur_path, encoding="utf-8").read()
    block = open(new_path, encoding="utf-8").read().rstrip("\n") + "\n"

--- a/.copilot/skills/weekly-reflection/references/template.md
+++ b/.copilot/skills/weekly-reflection/references/template.md
@@ -4,7 +4,7 @@
 
 1. Drive Trusted Type Violations to zero in UI Service and for reported bug bounty surfaces
    -
-2. Consult with Matt / Derrick etc on how to increase copilot usage from 900 tokens to 3k tokens per week
+2. Reflect on my AI usage and how to improve it — adopt new modalities and leverage AI to increase my productivity
    -
 3. Look for regular opportunities to communicate current work more broadly: Core UX discussions, ADRs, Decision Records (others?)
    -

--- a/.copilot/skills/weekly-reflection/references/template.md
+++ b/.copilot/skills/weekly-reflection/references/template.md
@@ -2,12 +2,12 @@
 
 ## 🥅 Goal Progress
 
-1. Drive Trusted Type Violations to zero in UI Service and for reported bug bounty surfaces 
- - 
-2. Consult with Matt / Derrick etc on how to increase copilot usage from 900 tokens to 3k tokens per week 
- - 
-3. Look for regular opportunities to communicate current work more broadly: Core UX discussions, ADRs, Decision Records (others?) 
- - 
+1. Drive Trusted Type Violations to zero in UI Service and for reported bug bounty surfaces
+ -
+2. Consult with Matt / Derrick etc on how to increase copilot usage from 900 tokens to 3k tokens per week
+ -
+3. Look for regular opportunities to communicate current work more broadly: Core UX discussions, ADRs, Decision Records (others?)
+ -
 4. Efficiency of communication in person / when moderating meetings. Having better agenda planned / Ensuring meeting is achieving goals / How to communicate depth and breadth of technical topics succinctly 
  - 
 

--- a/.copilot/skills/weekly-reflection/references/template.md
+++ b/.copilot/skills/weekly-reflection/references/template.md
@@ -1,0 +1,26 @@
+# {{DATE}}
+
+## 🥅 Goal Progress
+
+1. Drive Trusted Type Violations to zero in UI Service and for reported bug bounty surfaces 
+ - 
+2. Consult with Matt / Derrick etc on how to increase copilot usage from 900 tokens to 3k tokens per week 
+ - 
+3. Look for regular opportunities to communicate current work more broadly: Core UX discussions, ADRs, Decision Records (others?) 
+ - 
+4. Efficiency of communication in person / when moderating meetings. Having better agenda planned / Ensuring meeting is achieving goals / How to communicate depth and breadth of technical topics succinctly 
+ - 
+
+## 🏗️ Work done
+
+## 🏆 Wins
+
+## 💩 Fails
+
+## 🙏 Kudos / Gratitude
+
+## 🌳 Decisions
+
+## 🔮 Ideas
+
+---

--- a/.copilot/skills/weekly-reflection/references/template.md
+++ b/.copilot/skills/weekly-reflection/references/template.md
@@ -3,13 +3,13 @@
 ## 🥅 Goal Progress
 
 1. Drive Trusted Type Violations to zero in UI Service and for reported bug bounty surfaces
- -
+   -
 2. Consult with Matt / Derrick etc on how to increase copilot usage from 900 tokens to 3k tokens per week
- -
+   -
 3. Look for regular opportunities to communicate current work more broadly: Core UX discussions, ADRs, Decision Records (others?)
- -
-4. Efficiency of communication in person / when moderating meetings. Having better agenda planned / Ensuring meeting is achieving goals / How to communicate depth and breadth of technical topics succinctly 
- - 
+   -
+4. Efficiency of communication in person / when moderating meetings. Having better agenda planned / Ensuring meeting is achieving goals / How to communicate depth and breadth of technical topics succinctly
+   -
 
 ## 🏗️ Work done
 

--- a/script/install-mac.sh
+++ b/script/install-mac.sh
@@ -58,9 +58,14 @@ echo "🔗 Linking Copilot CLI skills"
 echo
 
 mkdir -p "$HOME/.copilot/skills"
-for skill in "$HOME"/.dotfiles/.copilot/skills/*/; do
-  ln -sfn "${skill%/}" "$HOME/.copilot/skills/$(basename "$skill")"
-done
+skills_dir="$HOME/.dotfiles/.copilot/skills"
+if [ -d "$skills_dir" ]; then
+  shopt -s nullglob
+  for skill in "$skills_dir"/*/; do
+    ln -sfn "${skill%/}" "$HOME/.copilot/skills/$(basename "${skill%/}")"
+  done
+  shopt -u nullglob
+fi
 
 echo
 echo "✅ Copilot CLI MCP config linked"

--- a/script/install-mac.sh
+++ b/script/install-mac.sh
@@ -54,6 +54,9 @@ mkdir -p "$HOME/.copilot"
 ln -sfv "$HOME/.dotfiles/.copilot/mcp-config.json" "$HOME/.copilot/mcp-config.json"
 
 echo
+echo "✅ Copilot CLI MCP config linked"
+
+echo
 echo "🔗 Linking Copilot CLI skills"
 echo
 
@@ -68,7 +71,7 @@ if [ -d "$skills_dir" ]; then
 fi
 
 echo
-echo "✅ Copilot CLI MCP config linked"
+echo "✅ Copilot CLI skills linked"
 
 echo
 echo "🔑 Configuring git credential helpers"

--- a/script/install-mac.sh
+++ b/script/install-mac.sh
@@ -54,6 +54,15 @@ mkdir -p "$HOME/.copilot"
 ln -sfv "$HOME/.dotfiles/.copilot/mcp-config.json" "$HOME/.copilot/mcp-config.json"
 
 echo
+echo "🔗 Linking Copilot CLI skills"
+echo
+
+mkdir -p "$HOME/.copilot/skills"
+for skill in "$HOME"/.dotfiles/.copilot/skills/*/; do
+  ln -sfn "${skill%/}" "$HOME/.copilot/skills/$(basename "$skill")"
+done
+
+echo
 echo "✅ Copilot CLI MCP config linked"
 
 echo


### PR DESCRIPTION
## What

Adds two personal Copilot CLI skills, kept in dotfiles and symlinked into `~/.copilot/skills/`:

- **`bear`** — drive Bear.app notes through the bundled `bearcli` binary (`search`/`cat`/`show`/`create`/`append`/`edit`/`overwrite`/`tag`/…). Gives any agent Bear discoverability without running an always-on MCP server; the skill only loads when a request is Bear-related.
- **`weekly-reflection`** — prime this week's entry in the Bear "Weekly Work Diary" note from the weekly GitHub status updates. Fills the fixed template (Goal Progress, Work done, optional Wins/Fails/Kudos/Decisions/Ideas), formats each status update under a linked `h3` with its headings demoted a level, and prepends the finished block to the top of the diary note (newest week first).

## Install wiring

`script/install-mac.sh` now loops over `.copilot/skills/*` and symlinks each into `~/.copilot/skills/`, so any future skill dropped into dotfiles auto-installs with no per-skill edit. The symlinks are already created locally.

## Metadata handoff (context)

`weekly-reflection` locates the week's updates in this order, so it degrades gracefully when run on this Mac while the status update was posted elsewhere:

1. a best-effort handoff manifest at `~/.copilot/state/weekly-status/latest.json` (written by the `weekly-status-update` skill, if present and current);
2. local `*.post.md` session artifacts;
3. asking the user to paste the comment URL(s).

The producer-side manifest emission is a **follow-up** change to the `weekly-status-update` skill (different repo) and is intentionally optional — this PR only ships the consumer side.

## Notes

- Both skills call `bearcli` at `/Applications/Bear.app/Contents/MacOS/bearcli` (Bear 2.8+, not on `PATH`). No MCP server was added.
- `weekly-reflection` builds on `bear` for the CLI mechanics (identify-by-id, silent-on-success mutations, pipe body via stdin, back up before overwrite).
