### PR TITLE
Route dotfiles through ~/.dotfiles + add use-checkout worktree toggle

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -17,6 +17,8 @@ alias alloy="cd vendor/alloy"
 # shortcut to this project
 alias dotfiles="cd ~/.dotfiles"
 alias config="~/.dotfiles/script/setup.fish"
+# flip the live environment between the main checkout and a worktree
+alias dots-use="~/.dotfiles/script/use-checkout"
 alias csdotfiles="cd /home/vscode/.dotfiles"
 
 # work stuff

--- a/README.md
+++ b/README.md
@@ -5,8 +5,28 @@ My dot files
 ## Setup
 
 ```sh
-./scripts/setup.sh
+./script/setup
 ```
+
+## Working in a worktree (edit isolated, run live)
+
+Every dotfile in `$HOME` is symlinked through a single indirection symlink,
+`~/.dotfiles`, which normally points at this main checkout. Because the whole
+live environment resolves through that one pointer, you can develop a change in
+an isolated git worktree and have it run live on this machine by flipping
+`~/.dotfiles` at the worktree — then flip back when you're done.
+
+```sh
+# from anywhere in the repo (or a worktree of it):
+script/use-checkout /path/to/worktree   # live env now tracks the worktree
+script/use-checkout --status            # show where ~/.dotfiles points
+script/use-checkout --reset             # back to the main checkout
+```
+
+Open a new shell (`exec $SHELL -l`) to reload shell/git config; Copilot skills
+and other read-at-use configs pick up the change immediately. Only worktrees of
+this repo are accepted. Re-run `script/link-dotfiles` after adding a new tracked
+dotfile so it gets routed through `~/.dotfiles` too.
 
 ## Update `Brewfile`
 

--- a/script/link-dotfiles
+++ b/script/link-dotfiles
@@ -50,8 +50,11 @@ link_through_alias() {
 echo
 echo "🔗 Linking top-level dotfiles"
 # Enumerate from the canonical checkout so sources and targets always match.
-for path in "$MAIN"/.* "$MAIN"/*; do
-  name="$(basename "$path")"
+while IFS= read -r -d '' rel; do
+  case "$rel" in
+    */*) continue ;;
+  esac
+  name="$rel"
   case "$name" in
     .|..|.git) continue ;;                       # never touch . / .. / the git dir
     .config|.copilot|script|iterm|raycast) continue ;;  # dirs handled elsewhere / not linked wholesale
@@ -59,17 +62,17 @@ for path in "$MAIN"/.* "$MAIN"/*; do
     setup|*.md|*.txt) continue ;;                # docs / meta
   esac
   # Only link regular files at the top level; real dirs are handled explicitly.
-  [ -f "$path" ] || continue
+  [ -f "$MAIN/$rel" ] || continue
   link_through_alias "$name"
-done
+done < <(git -C "$MAIN" ls-files -z)
 
 echo
 echo "🔗 Linking .config files individually (untracked subdirs are preserved)"
 if [ -d "$MAIN/.config" ]; then
-  while IFS= read -r configfile; do
-    rel="${configfile#"$MAIN"/}"
+  while IFS= read -r -d '' rel; do
+    [ -f "$MAIN/$rel" ] || continue
     link_through_alias "$rel"
-  done < <(find "$MAIN/.config" -type f)
+  done < <(git -C "$MAIN" ls-files -z -- .config)
 fi
 
 echo

--- a/script/link-dotfiles
+++ b/script/link-dotfiles
@@ -1,0 +1,76 @@
+#!/bin/bash
+#
+# link-dotfiles — link tracked dotfiles into $HOME, routing every link
+# through ~/.dotfiles.
+#
+# ~/.dotfiles is a single indirection symlink that points at the canonical
+# (main) checkout of this repo. Because every dotfile in $HOME points at
+# ~/.dotfiles/<path> rather than at an absolute checkout path, flipping the one
+# ~/.dotfiles symlink (see `script/use-checkout`) atomically repoints the whole
+# live environment — shell, git, Copilot skills, Safari, .config, etc. — at a
+# git worktree, and back again.
+#
+# This script only creates symlinks. It has no other side effects and is safe
+# to re-run any time you add a new tracked dotfile.
+
+set -euo pipefail
+
+SCRIPTPATH="$( cd -- "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P )"
+REPO="$( cd -- "$SCRIPTPATH/.." >/dev/null 2>&1 && pwd -P )"
+ALIAS="$HOME/.dotfiles"
+
+# The canonical target for ~/.dotfiles is always the repo's *main* worktree, so
+# running this from a linked worktree still points the alias back at main.
+MAIN="$( git -C "$REPO" worktree list --porcelain 2>/dev/null | sed -n 's/^worktree //p' | head -1 || true )"
+[ -n "$MAIN" ] || MAIN="$REPO"
+
+echo "🔗 Pointing ~/.dotfiles at the main checkout"
+echo "   $ALIAS -> $MAIN"
+if [ -e "$ALIAS" ] && [ ! -L "$ALIAS" ]; then
+  echo "   ✋ $ALIAS exists and is not a symlink; refusing to replace it." >&2
+  exit 1
+fi
+ln -sfn "$MAIN" "$ALIAS"
+
+# Link $HOME/<rel> -> ~/.dotfiles/<rel>, replacing an existing symlink or regular
+# file but never clobbering a real directory.
+link_through_alias() {
+  local rel="$1"
+  local dest="$HOME/$rel"
+  local src="$ALIAS/$rel"
+  if [ -d "$dest" ] && [ ! -L "$dest" ]; then
+    echo "   ⚠️  skipping $dest (real directory, not a symlink)" >&2
+    return
+  fi
+  mkdir -p "$(dirname "$dest")"
+  ln -sfn "$src" "$dest"
+  echo "   $dest -> $src"
+}
+
+echo
+echo "🔗 Linking top-level dotfiles"
+# Enumerate from the canonical checkout so sources and targets always match.
+for path in "$MAIN"/.* "$MAIN"/*; do
+  name="$(basename "$path")"
+  case "$name" in
+    .|..|.git) continue ;;                       # never touch . / .. / the git dir
+    .config|.copilot|script|iterm|raycast) continue ;;  # dirs handled elsewhere / not linked wholesale
+    gnupg|ssh) continue ;;                        # leave GPG/SSH alone
+    setup|*.md|*.txt) continue ;;                # docs / meta
+  esac
+  # Only link regular files at the top level; real dirs are handled explicitly.
+  [ -f "$path" ] || continue
+  link_through_alias "$name"
+done
+
+echo
+echo "🔗 Linking .config files individually (untracked subdirs are preserved)"
+if [ -d "$MAIN/.config" ]; then
+  while IFS= read -r configfile; do
+    rel="${configfile#"$MAIN"/}"
+    link_through_alias "$rel"
+  done < <(find "$MAIN/.config" -type f)
+fi
+
+echo
+echo "✅ Dotfiles linked through ~/.dotfiles"

--- a/script/setup
+++ b/script/setup
@@ -8,88 +8,16 @@ echo "##################################################"
 echo
 echo
 
-# Install dotfiles into home directory
+# Resolve this script's location so we can call sibling scripts.
 SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
-DOTFILESDIR=$(dirname $SCRIPTPATH)
-DOTFILES=$(ls -a $DOTFILESDIR)
 
-echo "SCRIPTPATH: $SCRIPTPATH"
-echo "DOTFILESDIR: $DOTFILESDIR"
-echo "DOTFILES: $DOTFILES"
-
-# Move dotfiles to home directory
-echo
-echo "🔗 Linking dotfiles to home directory "
-echo
-
-for DOTFILE in $DOTFILES; do
-  HOMEFILE="$HOME/$DOTFILE"
-  [ -d $DOTFILE ] && DOTFILE="$DOTFILE/"
-  DIRFILE="$DOTFILESDIR/$DOTFILE"
-
-
-  # Don't mess with Codespaces' default GPG/SSH setup.
-  if [ -n "$CODESPACES" ]
-  then
-    echo $DOTFILE | grep -Eq '^(gnupg|ssh)/' && continue
-  fi
-
-  # Don't try to install documentation/script/lock files
-  echo $DOTFILE | grep -Eq '(\.\/$|^\.git\/$|^\.config\/$|^(script|iterm|raycast)\/$|setup|\.txt$|\.md$)' && continue
-
-  # .copilot/ contains machine-specific IDE data alongside tracked config;
-  # handle it separately in install-mac.sh
-  echo $DOTFILE | grep -Eq '^\.copilot\/$' && continue
-
-  if [ -L "$HOMEFILE" ] && ! [ -d $DOTFILE ]
-  then
-    ln -sfv "$DIRFILE" "$HOMEFILE"
-  else
-    rm -rv "$HOMEFILE" 2>/dev/null
-    ln -sv "$DIRFILE" "$HOMEFILE"
-  fi
-
-  echo 
-done
-
-# Link .config files individually so untracked dirs (gh/, op/, raycast/, etc.) are preserved
-echo
-echo "🔗 Linking .config files"
-echo
-
-# We symlink individual files rather than the whole .config/ dir so that
-# untracked subdirs (gh/, op/, raycast/, etc.) are left untouched.
-mkdir -p "$HOME/.config"
-find "$DOTFILESDIR/.config" -type f | while read CONFIGFILE; do
-  # Strip the dotfiles repo prefix to get the relative path, e.g. .config/fish/config.fish
-  RELPATH="${CONFIGFILE#$DOTFILESDIR/}"
-  HOMEFILE="$HOME/$RELPATH"
-  # Ensure the parent dir exists (e.g. ~/.config/fish/, ~/.config/mise/)
-  mkdir -p "$(dirname "$HOMEFILE")"
-  if [ -L "$HOMEFILE" ]; then
-    # Already a symlink — update it in place
-    ln -sfv "$CONFIGFILE" "$HOMEFILE"
-  else
-    # Real file or missing — remove and replace with symlink
-    rm -v "$HOMEFILE" 2>/dev/null
-    ln -sv "$CONFIGFILE" "$HOMEFILE"
-  fi
-  echo
-done
-
-HOME_DOTFILES_ALIAS="$HOME/.dotfiles"
-
-echo 
-echo "🔗 Creating a symlink in ~/.dotfiles to this dotfiles repo"
-echo
-
-if [ -L "$HOME_DOTFILES_ALIAS" ] && ! [ -d $DOTFILESDIR ]
-then
-  ln -sfv "$DOTFILESDIR" "$HOME_DOTFILES_ALIAS"
-else
-  rm -rv "$HOME_DOTFILES_ALIAS" 2>/dev/null
-  ln -sv "$DOTFILESDIR" "$HOME_DOTFILES_ALIAS"
-fi
+# Link tracked dotfiles into $HOME and (re)create the ~/.dotfiles alias.
+#
+# Every link is routed through ~/.dotfiles, so the entire live environment can
+# be flipped to a git worktree with `script/use-checkout` (see the README,
+# "Working in a worktree"). link-dotfiles only creates symlinks, so it is safe
+# to re-run any time you add a new tracked dotfile.
+"$SCRIPTPATH/link-dotfiles"
 
 $SCRIPTPATH/install.sh
 

--- a/script/setup
+++ b/script/setup
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 echo
 echo
 echo "##################################################"

--- a/script/use-checkout
+++ b/script/use-checkout
@@ -36,6 +36,12 @@ common_dir() {
     cd "$d" 2>/dev/null && pwd -P )
 }
 
+worktree_root() {
+  ( cd "$1" 2>/dev/null || exit 0
+    d="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+    cd "$d" 2>/dev/null && pwd -P )
+}
+
 current_target() { readlink "$ALIAS" 2>/dev/null || true; }
 
 classify() {
@@ -94,6 +100,8 @@ USAGE
     rc="$(common_dir "$REPO")"
     [ -n "$tc" ] || die "$target is not inside a git worktree"
     [ "$tc" = "$rc" ] || die "$target is not a worktree of this dotfiles repo"
-    repoint "$target"
+    root="$(worktree_root "$target")"
+    [ -n "$root" ] || die "$target is not inside a git worktree"
+    repoint "$root"
     ;;
 esac

--- a/script/use-checkout
+++ b/script/use-checkout
@@ -50,6 +50,9 @@ classify() {
 
 show_status() {
   local t; t="$(current_target)"
+  if [ -e "$ALIAS" ] && [ ! -L "$ALIAS" ]; then
+    die "$ALIAS exists and is not a symlink; refusing to report it as unset."
+  fi
   echo "~/.dotfiles -> ${t:-(none)}   [$(classify "$t")]"
 }
 

--- a/script/use-checkout
+++ b/script/use-checkout
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 #
 # use-checkout — flip the whole live dotfiles environment between checkouts.
 #

--- a/script/use-checkout
+++ b/script/use-checkout
@@ -33,7 +33,7 @@ main_worktree() {
 common_dir() {
   ( cd "$1" 2>/dev/null || exit 0
     d="$(git rev-parse --git-common-dir 2>/dev/null)" || exit 0
-    cd "$d" 2>/dev/null && pwd -P )
+    cd "$d" 2>/dev/null && pwd -P || exit 0 )
 }
 
 worktree_root() {

--- a/script/use-checkout
+++ b/script/use-checkout
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# use-checkout — flip the whole live dotfiles environment between checkouts.
+#
+# ~/.dotfiles is a single indirection symlink that every linked dotfile resolves
+# through (see script/link-dotfiles). Repointing it swaps the entire live
+# environment — shell, git, Copilot skills, Safari, .config, etc. — atomically,
+# so you can develop a change in an isolated git worktree while it runs live on
+# this machine, then flip back to the main checkout when you're done.
+#
+#   script/use-checkout <path>     point ~/.dotfiles at the given worktree
+#   script/use-checkout --reset    point ~/.dotfiles back at the main checkout
+#   script/use-checkout --status   show the current target (default)
+#
+# Only worktrees of THIS dotfiles repo are accepted, so the live environment
+# can't be aimed at an unrelated directory by mistake.
+
+set -euo pipefail
+
+ALIAS="$HOME/.dotfiles"
+SELF="$( cd -- "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P )"
+REPO="$( cd -- "$SELF/.." >/dev/null 2>&1 && pwd -P )"
+
+die() { echo "✋ $*" >&2; exit 1; }
+
+# First entry of `git worktree list` is always the repo's main worktree.
+main_worktree() {
+  git -C "$REPO" worktree list --porcelain 2>/dev/null | sed -n 's/^worktree //p' | head -1 || true
+}
+
+# Physical path of a checkout's shared git dir; identifies which repo a worktree
+# belongs to. Prints nothing if $1 isn't inside a git worktree.
+common_dir() {
+  ( cd "$1" 2>/dev/null || exit 0
+    d="$(git rev-parse --git-common-dir 2>/dev/null)" || exit 0
+    cd "$d" 2>/dev/null && pwd -P )
+}
+
+current_target() { readlink "$ALIAS" 2>/dev/null || true; }
+
+classify() {
+  local t="$1" main
+  main="$(main_worktree)"
+  if [ -z "$t" ]; then echo "unset"
+  elif [ ! -e "$t" ]; then echo "DANGLING"
+  elif [ -n "$main" ] && [ "$(cd "$t" 2>/dev/null && pwd -P)" = "$main" ]; then echo "main checkout"
+  else echo "worktree"
+  fi
+}
+
+show_status() {
+  local t; t="$(current_target)"
+  echo "~/.dotfiles -> ${t:-(none)}   [$(classify "$t")]"
+}
+
+repoint() {
+  local target="$1"
+  if [ -e "$ALIAS" ] && [ ! -L "$ALIAS" ]; then
+    die "$ALIAS exists and is not a symlink; refusing to replace it."
+  fi
+  ln -sfn "$target" "$ALIAS"
+  echo "✅ ~/.dotfiles -> $target"
+  local main; main="$(main_worktree)"
+  [ -n "$main" ] && echo "   restore main: $main/script/use-checkout --reset"
+  echo "   open a new shell (exec \$SHELL -l) to reload shell/git config;"
+  echo "   Copilot skills and other read-at-use configs update live."
+}
+
+cmd="${1:---status}"
+case "$cmd" in
+  --status|status)
+    show_status
+    ;;
+  --reset|reset|--main|main)
+    main="$(main_worktree)"
+    [ -n "$main" ] || die "could not locate the main checkout of $REPO"
+    repoint "$main"
+    ;;
+  -h|--help|help)
+    cat <<'USAGE'
+usage: use-checkout [<path> | --reset | --status]
+  <path>     point ~/.dotfiles at the given git worktree of this repo
+  --reset    point ~/.dotfiles back at the main checkout
+  --status   show the current target (default)
+USAGE
+    ;;
+  *)
+    [ -d "$cmd" ] || die "not a directory: $cmd"
+    target="$( cd "$cmd" >/dev/null 2>&1 && pwd -P )"
+    tc="$(common_dir "$target")"
+    rc="$(common_dir "$REPO")"
+    [ -n "$tc" ] || die "$target is not inside a git worktree"
+    [ "$tc" = "$rc" ] || die "$target is not a worktree of this dotfiles repo"
+    repoint "$target"
+    ;;
+esac

--- a/script/use-checkout
+++ b/script/use-checkout
@@ -39,7 +39,7 @@ common_dir() {
 worktree_root() {
   ( cd "$1" 2>/dev/null || exit 0
     d="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
-    cd "$d" 2>/dev/null && pwd -P )
+    cd "$d" 2>/dev/null && pwd -P || exit 0 )
 }
 
 current_target() { readlink "$ALIAS" 2>/dev/null || true; }


### PR DESCRIPTION
## What

Establishes a methodology for **editing dotfiles in an isolated git worktree while running them live on this machine**, generalized to the whole symlink surface (shell, git, Copilot skills, Safari, `.config`) — not just Copilot skills.

## Why

Copilot sessions run in per-branch worktrees (safe, isolated). But the live config on this Mac is symlinked from a checkout, and today those links are split:

- top-level dotfiles (`.zshrc`, `.gitconfig`, `Brewfile`, …) and `.config/*` → **absolute** path into the main checkout (created by `script/setup`);
- `.copilot/*` → routed through the `~/.dotfiles` indirection symlink (created by `install-mac.sh`).

So a worktree's edits were never live, and flipping the one `~/.dotfiles` pointer only moved the Copilot bits. Editing in a worktree and running it live were mutually exclusive.

## How

Make `~/.dotfiles` the **single indirection** that every live symlink resolves through, then flip that one pointer to switch environments atomically.

- **`script/link-dotfiles`** *(new)* — pure symlinker extracted from `setup`. Points `~/.dotfiles` at the repo's **main** worktree, then links every top-level dotfile and `.config/*` as `$HOME/<rel> → ~/.dotfiles/<rel>`. No brew/dock/install side effects; safe to re-run when you add a new tracked dotfile. Never clobbers a real directory. `.copilot/*` stays owned by `install-mac.sh` (already routed).
- **`script/use-checkout`** *(new)* — the toggle:
  - `use-checkout <path>` → point `~/.dotfiles` at a git worktree (live env now tracks it)
  - `use-checkout --reset` → back to the main checkout
  - `use-checkout --status` → show the current target
  - Only worktrees of **this** repo are accepted, so the live env can't be aimed at an unrelated dir.
- **`script/setup`** now calls `link-dotfiles` instead of inlining the loops.
- **README** documents the workflow; **`.aliases`** adds a `dots-use` shortcut.

## Testing

Validated end-to-end against a throwaway `HOME` (no live symlinks touched): top-level + `.config` links route through `~/.dotfiles`; flip makes `.zshrc` resolve into the worktree; `--reset` restores the main checkout; and it refuses non-worktree / missing paths.

## Rollout

After merge, run `script/link-dotfiles` once from the updated main checkout to convert the existing absolute `~` links to the routed form (same resolved targets — safe and reversible). From then on, `dots-use <worktree>` / `--reset` flips the whole environment.