### PR TITLE
Add personal Copilot CLI code-comment-quality instruction

### DIFF
--- a/.copilot/copilot-instructions.md
+++ b/.copilot/copilot-instructions.md
@@ -1,0 +1,15 @@
+# Personal Copilot CLI instructions
+
+User-level instructions applied across all repositories on this machine.
+
+## Code comment quality
+
+Comments state only the facts needed to interpret what the code does and its
+current state. They must not contain narrative, planning, methodology, or
+issue-sequencing.
+
+- A header like `WHAT THIS BRANCH DELIVERS:` belongs in a PR description, not in
+  a code comment. The code is the permanent record; process history is not.
+- Record deferred context only when it matters — e.g. a glaring, intentional
+  omission planned as a follow-up. Use `// TODO: {issue link}: {context}`.
+- Otherwise, stick to facts and current state.

--- a/script/install-linux.sh
+++ b/script/install-linux.sh
@@ -57,6 +57,16 @@ echo "✅ Copilot CLI MCP config linked"
 echo
 
 echo
+echo "🔗 Linking Copilot CLI custom instructions"
+echo
+
+ln -sfv "$HOME/.dotfiles/.copilot/copilot-instructions.md" "$HOME/.copilot/copilot-instructions.md"
+
+echo
+echo "✅ Copilot CLI custom instructions linked"
+echo
+
+echo
 echo "🔑 Configuring git credential helpers"
 echo
 

--- a/script/install-mac.sh
+++ b/script/install-mac.sh
@@ -57,6 +57,15 @@ echo
 echo "✅ Copilot CLI MCP config linked"
 
 echo
+echo "🔗 Linking Copilot CLI custom instructions"
+echo
+
+ln -sfv "$HOME/.dotfiles/.copilot/copilot-instructions.md" "$HOME/.copilot/copilot-instructions.md"
+
+echo
+echo "✅ Copilot CLI custom instructions linked"
+
+echo
 echo "🔗 Linking Copilot CLI skills"
 echo
 


### PR DESCRIPTION
## What

Adds a personal, cross-repo GitHub Copilot CLI custom instruction that constrains code-comment quality, and wires it into the install scripts.

## Mechanism

The supported location for **user-level** (cross-repository) Copilot CLI instructions is `$HOME/.copilot/copilot-instructions.md` — per the [official docs](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-custom-instructions) ("User-level instructions that apply across repositories"). This is distinct from repo-scoped `.github/copilot-instructions.md`.

- Adds `.copilot/copilot-instructions.md` (tracked in dotfiles).
- `script/install-mac.sh` and `script/install-linux.sh` now symlink it into `~/.copilot/copilot-instructions.md`, matching the existing `mcp-config.json` wiring.

## The rule

Code comments state only the facts needed to interpret what the code does and its current state — no narrative, planning, methodology, or issue-sequencing. Headers like `WHAT THIS BRANCH DELIVERS:` belong in a PR description, not the permanent record. Deferred context is recorded only as `// TODO: {issue link}: {context}`.

## Applied to this machine

`~/.copilot/copilot-instructions.md` now resolves to the tracked file and reflects the rule immediately. On future `script/setup` runs the install step re-points the link through `~/.dotfiles`, consistent with `mcp-config.json`.