### PR TITLE
Add plain-language Copilot guidance

### DIFF
--- a/.copilot/copilot-instructions.md
+++ b/.copilot/copilot-instructions.md
@@ -2,6 +2,15 @@
 
 User-level instructions applied across all repositories on this machine.
 
+## User-facing communication
+
+- Lead with the practical answer.
+- Use short sentences and everyday words.
+- Define necessary technical terms immediately.
+- Avoid unexplained acronyms and internal jargon.
+- Use examples for concepts that can confuse non-specialists.
+- Preserve precision without needlessly complex phrasing.
+
 ## Code comment quality
 
 Comments state only the facts needed to interpret what the code does and its


### PR DESCRIPTION
## Summary
- add durable plain-language rules for user-facing Copilot responses
- preserve the existing instruction structure and code-comment guidance

## Validation
- git diff --check